### PR TITLE
Fix typo in JSDoc for starttls

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ export default class SimpleLDAPSearch {
   }
 
   /**
-   * Secures the LDAP opject by using the STARTTLS verb
+   * Secures the LDAP object by using the STARTTLS verb
    * @param {Object} opts - STARTTLS options
    * @returns {Promise|Error} - Resolves the promise or returns the error from ldapjs
    */


### PR DESCRIPTION
## Summary
- fix JSDoc typo in `starttls` description

## Testing
- `npm test` *(fails: Cannot find module 'jest')*