### PR TITLE
Add TypeError test for arrayIncludesFunction

### DIFF
--- a/lib/arrayIncludesFunction.test.js
+++ b/lib/arrayIncludesFunction.test.js
@@ -35,4 +35,8 @@ describe('arrayIncludesFunction', () => {
 
     expect(arrayIncludesFunction(arr, print2)).toBe(false);
   });
+
+  it('throws TypeError if fn is not a function', () => {
+    expect(() => arrayIncludesFunction([1, 2, 3], 5)).toThrow(TypeError);
+  });
 });


### PR DESCRIPTION
## Summary
- add a test verifying arrayIncludesFunction throws when given a non-function

## Testing
- `npm test` *(fails: cannot find module 'jest')*