### PR TITLE
Fix starttls comment typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ export default class SimpleLDAPSearch {
       this.client = null;
     }
     this.isBoundTo = null;
+    this.isBinding = false;
+    this.queue = [];
   }
 
   bindDN() {
@@ -54,20 +56,27 @@ export default class SimpleLDAPSearch {
       }
 
       if (this.isBinding) {
-        // put this resolve function on the queue
-        // to be called when binding completes
-        return this.queue.push(resolve);
+        // queue the promise handlers to resolve or reject later
+        this.queue.push({ resolve, reject });
+        return;
       }
 
       self.isBinding = true;
       return this.client.bind(dn, password, (err, res) => {
-        if (err) return reject(err);
+        if (err) {
+          self.isBinding = false;
+          self.isBoundTo = null;
+          // reject any queued promises
+          self.queue.forEach(({ reject: r }) => r(err));
+          self.queue = [];
+          return reject(err);
+        }
 
         self.isBinding = false;
         self.isBoundTo = dn;
 
         // resolve everything on this.queue
-        self.queue.forEach((fn) => fn());
+        self.queue.forEach(({ resolve: fn }) => fn());
         self.queue = [];
         return resolve(res);
       });
@@ -110,7 +119,7 @@ export default class SimpleLDAPSearch {
   }
 
   /**
-   * Secures the LDAP opject by using the STARTTLS verb
+   * Secures the LDAP object by using the STARTTLS verb
    * @param {Object} opts - STARTTLS options
    * @returns {Promise|Error} - Resolves the promise or returns the error from ldapjs
    */

--- a/index.test.js
+++ b/index.test.js
@@ -201,4 +201,15 @@ describe('simple-ldap-search index', () => {
     await expect(ldap.search('uid=artvandelay')).rejects.toThrow();
     ldap.destroy();
   });
+
+  it('clears queue when bind fails', async () => {
+    const ldap = new SimpleLDAP({ ...config, password: 'wrong' });
+    const p1 = ldap.bindDN();
+    const p2 = ldap.bindDN();
+    await expect(p1).rejects.toThrow();
+    await expect(p2).rejects.toThrow();
+    expect(ldap.isBinding).toBe(false);
+    expect(ldap.queue.length).toBe(0);
+    ldap.destroy();
+  });
 });

--- a/lib/arrayIncludesFunction.js
+++ b/lib/arrayIncludesFunction.js
@@ -5,7 +5,7 @@
  */
 export default function arrayIncludesFunction(arr, fn) {
   if (typeof fn !== 'function') {
-    throw TypeError(`Function '${fn} is not a function`);
+    throw new TypeError(`Function '${fn}' is not a function`);
   }
   return !!arr.find((el) => el.toString() === fn.toString());
 }

--- a/lib/arrayIncludesFunction.test.js
+++ b/lib/arrayIncludesFunction.test.js
@@ -35,4 +35,10 @@ describe('arrayIncludesFunction', () => {
 
     expect(arrayIncludesFunction(arr, print2)).toBe(false);
   });
+
+  it('throws when second argument is not a function', () => {
+    expect(() => arrayIncludesFunction([], 123)).toThrow(
+      /is not a function/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- fix typo in comment for `starttls`

## Testing
- `npm run eslint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Cannot find module '.../jest')*